### PR TITLE
fix: support ethermint's EIP712 implementation

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -500,7 +500,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
  */
 function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
-  if (verifyingContract && !isValidHexAddress(verifyingContract)) {
+  if (verifyingContract && !(isValidHexAddress(verifyingContract) || verifyingContract == 'cosmos')) {
     throw rpcErrors.invalidInput();
   }
 }


### PR DESCRIPTION
MM is broken since v12.1.1 for cosmos chains that use `https://github.com/evmos/ethermint` as EVM adapter.

`Ethermint` uses hard coded `"cosmos"` string as the `VerifyingContract` field, which is broken since `validateVerifyingContract` introduced in MM.

This PR adds support to allow "cosmos" as the `VerifyingContract` value.